### PR TITLE
Feature: CUDA support when cudaSupport is true

### DIFF
--- a/pkgs/alvr/default.nix
+++ b/pkgs/alvr/default.nix
@@ -20,6 +20,9 @@
 , x264
 , xorg
 , xvidcore
+, config
+, cudaPackages
+, cudaSupport ? config.cudaSupport
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "alvr";
@@ -63,6 +66,13 @@ stdenv.mkDerivation (finalAttrs: {
     xorg.libXcursor
     xorg.libxcb
     xorg.libXi
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+    cudaPackages.cuda_cudart
+    cudaPackages.libnpp
+    libva
+    libdrm
   ];
 
   installPhase = ''


### PR DESCRIPTION
I pilfered a few lines of Nix from an alvr PR to get Nvidia acceleration working, at least on my machine. Test-built it on a non-Nvidia system and did not accidentally pull any CUDA-related packages, so it should work for everyone. 