### PR TITLE
drop android-udev-rules

### DIFF
--- a/modules/nixos/wivrn/default.nix
+++ b/modules/nixos/wivrn/default.nix
@@ -188,7 +188,6 @@ in
     };
 
     services = {
-      udev.packages = with pkgs; [ android-udev-rules ];
       avahi = {
         enable = true;
         publish = {


### PR DESCRIPTION
`udev.packages = with pkgs; [ android-udev-rules ];` is no-longer needed. See NixOS/nixpkgs#454366.