### PR TITLE
feature: gate build-scheduler from update workflow

### DIFF
--- a/.github/workflows/build-scheduler.yml
+++ b/.github/workflows/build-scheduler.yml
@@ -14,9 +14,25 @@ on:
       - completed
 
 jobs:
+  # The update workflow finishing will trigger a build so don't run the build workflow if both were to be triggered
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      nvfetcher: ${{ steps.filter.outputs.nvfetcher }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            nvfetcher:
+              - 'nvfetcher.toml'
+
   build-scheduler:
+    needs: changes
     # Don't run the build if the update workflow failed because nothing will have changed
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event_name != 'workflow_run' && needs.changes.outputs.nvfetcher != 'true') || github.event.workflow_run.conclusion == 'success'}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,9 @@
 name: Update
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - 'nvfetcher.toml'
   schedule:
   - cron: '0 2 * * *'
 


### PR DESCRIPTION
If update is run, don't also run build-scheduler because the packages will be out-of-date when built the first time. The update workflow will still call build-scheduler when it succeeds